### PR TITLE
Rename update-zblinks-api-->zbmath-links-api

### DIFF
--- a/src/update_zblinks_api/matrix_table_datasets.py
+++ b/src/update_zblinks_api/matrix_table_datasets.py
@@ -44,7 +44,7 @@ def create_deids_table_dataset(partner, df_hist):
         )
     )
 
-    dist = get_distribution("update-zblinks-api")
+    dist = get_distribution("zbmath-links-api")
     df_hist["matched_by"] = dist.project_name
     df_hist["matched_by_version"] = dist.version
 

--- a/src/update_zblinks_api/matrix_table_datasets.py
+++ b/src/update_zblinks_api/matrix_table_datasets.py
@@ -44,8 +44,8 @@ def create_deids_table_dataset(partner, df_hist):
         )
     )
 
-    dist = get_distribution("zbmath-links-api")
-    df_hist["matched_by"] = dist.project_name
+    dist = get_distribution("update-zblinks-api")
+    df_hist["matched_by"] = "zbmath-links-api"
     df_hist["matched_by_version"] = dist.version
 
     if "zbl_code" in df_hist.columns:

--- a/src/update_zblinks_api/matrix_table_datasets.py
+++ b/src/update_zblinks_api/matrix_table_datasets.py
@@ -1,5 +1,6 @@
 import click
 import pandas as pd
+from pkg_resources import get_distribution
 
 import importlib
 
@@ -43,8 +44,9 @@ def create_deids_table_dataset(partner, df_hist):
         )
     )
 
+    dist = get_distribution("update-zblinks-api")
     df_hist["matched_by"] = "zbmath-links-api"
-    df_hist["matched_by_version"] = "1.0.0"
+    df_hist["matched_by_version"] = dist.version
 
     if "zbl_code" in df_hist.columns:
         df_hist = get_des_from_zbl_ids(df_hist)

--- a/src/update_zblinks_api/matrix_table_datasets.py
+++ b/src/update_zblinks_api/matrix_table_datasets.py
@@ -1,6 +1,5 @@
 import click
 import pandas as pd
-from pkg_resources import get_distribution
 
 import importlib
 
@@ -44,9 +43,8 @@ def create_deids_table_dataset(partner, df_hist):
         )
     )
 
-    dist = get_distribution("update-zblinks-api")
     df_hist["matched_by"] = "zbmath-links-api"
-    df_hist["matched_by_version"] = dist.version
+    df_hist["matched_by_version"] = "1.0.0"
 
     if "zbl_code" in df_hist.columns:
         df_hist = get_des_from_zbl_ids(df_hist)


### PR DESCRIPTION
Match the zblinks package spec, cf.

https://github.com/zbMATHOpen/linksApi/blob/bd52f22e8e479232a6fdfd878cf7e119b6ec2797/src/zb_links/api/link/helpers/link_helpers.py#L8